### PR TITLE
add utcnow function and unit tests

### DIFF
--- a/include/s3select.h
+++ b/include/s3select.h
@@ -651,9 +651,8 @@ struct s3select : public bsc::grammar<s3select>
 
             mulldiv_operand = arithmetic_argument | ('(' >> (arithmetic_expression) >> ')') ; 
 
-            list_of_function_arguments = (arithmetic_expression)[BOOST_BIND_ACTION(push_function_arg)] >> *(',' >> (arithmetic_expression)[BOOST_BIND_ACTION(push_function_arg)]) ;
-
-            function =( (variable >>  '(' )[BOOST_BIND_ACTION(push_function_name)]   >> list_of_function_arguments >> ')' ) [BOOST_BIND_ACTION(push_function_expr)];
+            list_of_function_arguments = (arithmetic_expression)[BOOST_BIND_ACTION(push_function_arg)] >> *(',' >> (arithmetic_expression)[BOOST_BIND_ACTION(push_function_arg)]);
+            function = ((variable >> '(' )[BOOST_BIND_ACTION(push_function_name)] >> !list_of_function_arguments >> ')')[BOOST_BIND_ACTION(push_function_expr)];
             
             arithmetic_argument = (float_number)[BOOST_BIND_ACTION(push_float_number)] |  (number)[BOOST_BIND_ACTION(push_number)] | (column_pos)[BOOST_BIND_ACTION(push_column_pos)] | 
                                 (string)[BOOST_BIND_ACTION(push_string)] |

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -1,6 +1,8 @@
 #include "s3select.h"
 #include "gtest/gtest.h"
 #include <string>
+#include "boost/date_time/gregorian/gregorian.hpp"
+#include "boost/date_time/posix_time/posix_time.hpp"
 
 using namespace s3selectEngine;
 
@@ -213,5 +215,26 @@ TEST(TestS3SElect, arithmetic_operator)
 
 	a=int64_t(1); //a+b modify a
 	ASSERT_EQ( ( (a+b) * (c+d) ).i64() , 21 );
+}
+
+TEST(TestS3SElect, timestamp_function)
+{
+    // TODO: support formats listed here:
+    // https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference-date.html#s3-glacier-select-sql-reference-to-timestamp
+    const std::string timestamp = "2007-02-23:14:33:01";
+    // TODO: out_simestamp should be the same as timestamp
+    const std::string out_timestamp = "2007-Feb-23 14:33:01";
+    const std::string input_query = "select timestamp(\"" + timestamp + "\") from stdin;" ;
+	std::string s3select_res = run_s3select(input_query);
+    ASSERT_EQ(s3select_res, out_timestamp);
+}
+
+TEST(TestS3SElect, utcnow_function)
+{
+    const boost::posix_time::ptime now(boost::posix_time::second_clock::universal_time());
+    const std::string input_query = "select utcnow() from stdin;" ;
+	auto s3select_res = run_s3select(input_query);
+    const boost::posix_time::ptime res_now;
+    ASSERT_EQ(s3select_res, boost::posix_time::to_simple_string(now));
 }
 


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

- [x] tests are crashing - fixed in https://github.com/galsalomon66/s3select/pull/3
- [x] parser had to be modified to allow for functions without any parameters. could not do that with the `optional` parser (failed to compile). So I used the `kleene` parser
- [x] added a test for existing `timestamp()` function, added workaround for it to pass (comment in the code)
- [x] added a tests for the new `utcnow()` function, added workaround for it to pass (comment in the code)