### PR TITLE
add unit tests for functions and operators

### DIFF
--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -315,7 +315,7 @@ public:
 			            m_to_string.assign( boost::lexical_cast<std::string>(__val.num) );
                 }else if(type == value_En_t::FLOAT){
                         m_to_string = std::to_string(__val.dbl);
-                }else {
+                }else if (type == value_En_t::TIMESTAMP) {
                         m_to_string =  to_simple_string( *__val.timestamp );
                 }
         }else{


### PR DESCRIPTION
also fix a crash - deref a timestamp pointer that was null

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

note that the aggregate tests are currently failing, becasue it seems like only 9 rows are processed from the object