### PR TITLE
Cast days() result to int64_t

### DIFF
--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -680,7 +680,7 @@ struct _fn_diff_timestamp : public base_function
     {
       boost::gregorian::date_period dp =
         boost::gregorian::date_period( val_dt1.timestamp()->date(), val_dt2.timestamp()->date());
-      result->set_value( dp.length().days() );
+      result->set_value( (int64_t) dp.length().days() );
     }
     else if (strcmp(val_date_part.str(), "hours") == 0)
     {


### PR DESCRIPTION
Method days() in boost::gregorian::date_duration returns long and it breaks compilation on 32 bit system. We should cast days() result into int64_t to use appropriate set_value() method.

Signed-off-by: Vladimir Bashkirtsev <vladimir@bashkirtsev.com>